### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In Xml you can also specify *progressBackgroundColor* - by default the progressB
 Repository available on jCenter
 
 ```groovy
-compile 'com.minimize.library:seekbar-compat:0.3.0'
+implementation 'com.minimize.library:seekbar-compat:0.3.0'
 ```
 *If the dependency fails to resolve, add this to your project repositories*
 ```groovy


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.